### PR TITLE
Modified a line in the document

### DIFF
--- a/tex/SMTGeom.tex
+++ b/tex/SMTGeom.tex
@@ -110,7 +110,7 @@ and geometric problems can be translated (as we illustrate in this article) into
 associate to a geometric problem equations and inequations with real coefficients,
 with satisfiability meaning that we can
 assign real values to the variables so the equations and inequations are satisfied.
-A geometric statement is false if and only if the corresponding equations and inequations are \emph{unsatisfiable}. Thus, to prove a theorem in geometry, one can translate the negation of the theorem statement into a system of equations and inequations and verify that it is unsatisfiable (i.e., there are no real solutions).
+A geometric statement is universally false (i.e., the statement never holds) if and only if the corresponding equations and inequations are \emph{unsatisfiable}. Thus, to prove a theorem in geometry, one can translate the negation of the theorem statement into a system of equations and inequations and verify that it is unsatisfiable (i.e., there are no real solutions).
 
 In the 1950s, Tarski proved that whether a (finite)
 collection of polynomial equations and inequations has solutions that


### PR DESCRIPTION
A geometric statement is universally false (i.e., the statement never holds) if and only if the corresponding equations and inequations are \emph{unsatisfiable}. Thus, to prove a theorem in geometry, one can translate the negation of the theorem statement into a system of equations and inequations and verify that it is unsatisfiable (i.e., there are no real solutions).